### PR TITLE
Add XLX6, XLX7, YHM1, and YOW3 to amazon-fulfillment-centers.json

### DIFF
--- a/src/data/amazon-fulfillment-centers.json
+++ b/src/data/amazon-fulfillment-centers.json
@@ -6043,7 +6043,15 @@
     "country": "CA",
     "state": ""
   },
+  "YHM1": {
+    "country": "CA",
+    "state": ""
+  },
   "YOW1": {
+    "country": "CA",
+    "state": ""
+  },
+  "YOW3": {
     "country": "CA",
     "state": ""
   },

--- a/src/data/amazon-fulfillment-centers.json
+++ b/src/data/amazon-fulfillment-centers.json
@@ -5887,6 +5887,14 @@
     "country": "US",
     "state": "VA"
   },
+  "XLX6": {
+    "country": "US",
+    "state": "NC"
+  },
+  "XLX7": {
+    "country": "US",
+    "state": "CA"
+  },
   "XMN1": {
     "country": "CN",
     "state": ""


### PR DESCRIPTION
Hi,

Thank you for this comprehensive list. I found it very helpful.

I came across XLX6 & XLX7 in my data, and found them to be missing from the list.

![image](https://github.com/sonnenglas/amazon-fba-fulfillment-center-list/assets/37113831/8f22ef4c-fe08-4da5-bc8d-675c41c27794)
Source: https://www.jiufanglogistics.com/amazon-fba-warehouse-locations/

Here's a PR as a token of my gratitude.